### PR TITLE
Additional fixes based on real-life experience, see #13

### DIFF
--- a/src/completion.ts
+++ b/src/completion.ts
@@ -35,7 +35,6 @@ export class CompletionSupport {
           'autocomplete',
           '--strip-root',
           '--json',
-          '--no-auto-start',
           fileName,
           line,
           col

--- a/src/diagnostics.ts
+++ b/src/diagnostics.ts
@@ -41,6 +41,7 @@ function updateDiagnostics(document, flowPath): void {
     flowPath,
     [
       'check-contents',
+      '--respect-pragma',
       '--json',
       document.uri.fsPath,
     ],
@@ -74,7 +75,7 @@ function clean(diagnostics) {
   };
 
   diagnostics.map(e => {
-    desc = '';    
+    desc = '';
     return e.message.map((m) => {
       const path = m.path;
       if (cleaned[path] === undefined) {

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -24,7 +24,7 @@ export function flowCommand(flowPath, commandList:Array<string>, cb) {
       if (flowOutput.length) {
         o = JSON.parse(flowOutput);
       }
-      if (flowOutputError.length) {
+      if (flowOutputError.length && (code === null || code)) {
         return vscode.window.showInformationMessage(flowOutputError);
       }
       return cb(o);

--- a/src/hover.ts
+++ b/src/hover.ts
@@ -16,7 +16,6 @@ export class HoverSupport {
       const flowInstance = flowCommand(flowPath, [
         'type-at-pos',
         '--json',
-        '--no-auto-start',
         fileName,
         line.toString(),
         col.toString()


### PR DESCRIPTION
- We shouldn't check files if they do not have `@flow` pragma and config is not set to do so (--respect-pragma)
- Error output should be only if there is a failure (will stop annoying users with "Flow is still initializing..."). Please take a note the check (code !== null || code > 0) is not an error - "null" error code means something really serious happened :)
- Allow flow autostart when needed
